### PR TITLE
docs: add AI agent context + non-serve guard (chat.nano.org)

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,0 +1,4 @@
+# Don't upload agent instruction files as public Pages assets.
+# (Belt-and-suspenders; _redirects is the guaranteed guard.)
+AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent instructions — chat-nano-org (chat.nano.org)
+
+Static landing page that redirects visitors into the Nano **Discord** via a
+captcha-gated invite. Live at **chat.nano.org** on **Cloudflare Pages**.
+
+Task tracking is **beads** — run `bd prime` first.
+
+## What's here
+
+- `index.html` + `css/` + `images/` — the static Webflow-exported page.
+- `functions/getInvite.js` — a **Cloudflare Pages Function** (runs at the edge)
+  that solves the captcha and mints a Discord invite. It uses the Workers-native
+  `fetch`; no Node/AWS dependencies. (This replaced the old AWS Lambda.)
+
+## Make a change and ship it
+
+- Edit the files, open a PR, merge to **`main`**. GitHub Actions
+  (`.github/workflows/deploy.yml`) runs `wrangler pages deploy .` to the
+  `chat-nano-org` Pages project. Every PR gets a preview URL.
+- Discord invite secrets are Cloudflare Pages env vars (set in the dashboard),
+  not in git.
+
+## Infra
+
+For the overall nano.org topology and the Cloudflare deploy token, see the
+**[shared infra map](https://github.com/nanocurrency/nano-org/blob/main/docs/agents/INFRA.md)**.
+
+## Agent-doc policy — IMPORTANT (this repo is served from its root)
+
+`wrangler pages deploy .` uploads the **entire repo root**, so any root file is
+publicly fetchable. To keep agent docs from leaking:
+
+- **`_redirects`** sends `/AGENTS.md` and `/CLAUDE.md` to `/` (301). Cloudflare
+  applies `_redirects` before serving static assets and *always* follows them,
+  so the markdown is never served even though it is uploaded.
+- **`.assetsignore`** additionally asks Wrangler not to upload them.
+
+If you add more agent material (e.g. a `docs/agents/` dir), add a matching
+`_redirects` line and verify with:
+`curl -sI https://chat.nano.org/AGENTS.md` → expect `301`, no markdown body.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+Instructions for this repo live in **[AGENTS.md](./AGENTS.md)** (shared by all
+agents). Run `bd prime` for task-tracking (beads) context.

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,5 @@
+# Keep agent instruction files from being publicly served.
+# Cloudflare Pages applies _redirects before static assets and always follows
+# them, so these paths never return the underlying markdown. See AGENTS.md.
+/AGENTS.md / 301
+/CLAUDE.md / 301


### PR DESCRIPTION
## What

Adds standardized AI-agent context (bead nano_site_move-s34.2) for chat.nano.org.

- `AGENTS.md` / `CLAUDE.md` — short onboarding; links to the shared infra map.

## Leak guard (this repo is served from its root)

`wrangler pages deploy .` uploads the entire repo root, so root files are publicly fetchable (confirmed: `/README.md` and even `/.github/workflows/deploy.yml` return **200** today).

- **`_redirects`** 301s `/AGENTS.md` and `/CLAUDE.md` to `/`. Cloudflare applies `_redirects` before static assets and always follows them, so the markdown is never served even though uploaded.
- **`.assetsignore`** additionally asks Wrangler not to upload them.

After merge, verify: `curl -sI https://chat.nano.org/AGENTS.md` → expect `301`, no markdown body. The PR preview build can be checked the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)