### PR TITLE
Fix: chat.nano.org serves AGENTS.md/CLAUDE.md (guard bypassed)

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,4 +1,0 @@
-# Don't upload agent instruction files as public Pages assets.
-# (Belt-and-suspenders; _redirects is the guaranteed guard.)
-AGENTS.md
-CLAUDE.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Strip non-served files before upload
+        # `wrangler pages deploy .` uploads the entire root, and Cloudflare Pages
+        # serves a static asset in preference to a _redirects rule — so the only
+        # reliable way to keep the agent docs from being served is to not upload
+        # them. Removing them here (on the CI checkout only) leaves _redirects to
+        # turn /AGENTS.md and /CLAUDE.md into clean 301s.
+        run: rm -f AGENTS.md CLAUDE.md
       - name: Deploy to Cloudflare Pages
         id: deploy
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,18 @@ For the overall nano.org topology and the Cloudflare deploy token, see the
 ## Agent-doc policy — IMPORTANT (this repo is served from its root)
 
 `wrangler pages deploy .` uploads the **entire repo root**, so any root file is
-publicly fetchable. To keep agent docs from leaking:
+publicly fetchable. Cloudflare Pages serves a **static asset in preference to a
+`_redirects` rule**, so a redirect alone does *not* stop an uploaded file from
+being served (`.assetsignore` is a Workers-Assets feature and is not honored by
+`pages deploy` either). The reliable guard is therefore to **not upload them**:
 
-- **`_redirects`** sends `/AGENTS.md` and `/CLAUDE.md` to `/` (301). Cloudflare
-  applies `_redirects` before serving static assets and *always* follows them,
-  so the markdown is never served even though it is uploaded.
-- **`.assetsignore`** additionally asks Wrangler not to upload them.
+- **`.github/workflows/deploy.yml`** runs `rm -f AGENTS.md CLAUDE.md` on the CI
+  checkout right before `wrangler pages deploy .`, so the files are never part
+  of the deployment.
+- **`_redirects`** still lists `/AGENTS.md` and `/CLAUDE.md` → `/` (301). With
+  the assets removed at deploy, that redirect now actually fires (a request
+  returns a 301, not the markdown).
 
-If you add more agent material (e.g. a `docs/agents/` dir), add a matching
-`_redirects` line and verify with:
+If you add more agent material (e.g. a `docs/agents/` dir), add it to the
+`rm -f` list in the workflow **and** a matching `_redirects` line, then verify:
 `curl -sI https://chat.nano.org/AGENTS.md` → expect `301`, no markdown body.


### PR DESCRIPTION
## Problem

After merging #10, `https://chat.nano.org/AGENTS.md` and `/CLAUDE.md` return **HTTP 200 and serve the markdown**. The `_redirects` 301 guard does **not** work: Cloudflare Pages serves a **static asset in preference to a `_redirects` rule**, so an uploaded file at that path wins over the redirect. `.assetsignore` is a Workers-Assets feature and is not honored by `wrangler pages deploy` either.

(Severity is low — `chat-nano-org` is a public repo, so the content is already on GitHub and the file holds no secret values — but it violates the "don't serve agent files" requirement.)

## Fix

Strip the files on the CI checkout right before upload, so they're never deployed:

```yaml
- name: Strip non-served files before upload
  run: rm -f AGENTS.md CLAUDE.md
```

With the assets gone, the existing `_redirects` entries now actually fire (301). Also removes the non-functional `.assetsignore` and corrects the AGENTS.md policy note (which previously claimed, incorrectly, that `_redirects` always wins over assets).

## Verify after deploy

```
curl -sI https://chat.nano.org/AGENTS.md   # -> 301, no markdown body
curl -sI https://chat.nano.org/CLAUDE.md   # -> 301, no markdown body
```

Note: `README.md` and `/.github/workflows/deploy.yml` are also served (pre-existing, tracked as `nano_site_move-s34.5`) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)